### PR TITLE
Port to qt5

### DIFF
--- a/viz/CMakeLists.txt
+++ b/viz/CMakeLists.txt
@@ -1,3 +1,5 @@
+
+rock_find_qt5(Core)
 rock_vizkit_plugin(sbpl_spline_primitives-viz
     SbplSplineVisualization.cpp
     DEPS sbpl_spline_primitives

--- a/viz/SbplSplineVisualization.cpp
+++ b/viz/SbplSplineVisualization.cpp
@@ -177,9 +177,3 @@ void SbplSplineVisualization::addPrimitives(osg::Group* group,
   }
 }
 
-
-
-
-//Macro that makes this plugin loadable in ruby, this is optional.
-//VizkitQtPlugin(MotionPlanningLibrariesSbplSplineVisualization)
-

--- a/viz/SbplSplineVisualization.hpp
+++ b/viz/SbplSplineVisualization.hpp
@@ -53,5 +53,7 @@ namespace vizkit3d
         struct Data;
         Data* p;
     };
+
+    VizkitQtPlugin(SbplSplineVisualization)
 }
 #endif


### PR DESCRIPTION
@planthaber This is supposed to land on a branch called "feature/qt5", but github does not allow to specify that in a pull request, so that branch would have to be created beforehand.