### PR TITLE
Include local SbplSplineVisualization header

### DIFF
--- a/viz/gui/CMakeLists.txt
+++ b/viz/gui/CMakeLists.txt
@@ -11,6 +11,8 @@ rock_library(sbpl_viz_gui
     DEPS_PKGCONFIG vizkit3d base-types vizkit3d-viz base-viz 
 )
 
+target_include_directories(sbpl_viz_gui PRIVATE ${CMAKE_SOURCE_DIR}/viz)
+
 rock_executable(sbpl_spline_viz_bin
     SOURCES
         main.cpp

--- a/viz/gui/SbplGui.h
+++ b/viz/gui/SbplGui.h
@@ -3,8 +3,8 @@
 
 #ifndef Q_MOC_RUN
 #include <vizkit3d/Vizkit3DWidget.hpp>
-#include <vizkit3d/SbplSplineVisualization.hpp>
 #include <vizkit3d/GridVisualization.hpp>
+#include "SbplSplineVisualization.hpp"
 #include <base/Eigen.hpp>
 #endif
 


### PR DESCRIPTION
I observed a bug with how the SbplSplineVisualization.hpp file is included as `#include <vizkit3d/SbplSplineVisualization.hpp>` in SbplGui.hpp currently. In my case this included the (older) version of the file in my `install`-Directory and caused a build error as `SbplSplineVisualization::setMaxCurveLength` was missing in that version. I think including the `viz`-Directory and including the local header is a safer solution.